### PR TITLE
fix: create fresh Scope per test in ZTestLocalFixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ project/metals.sbt
 .bsp/
 .metals/
 .vscode/
+.claude/

--- a/core/src/main/scala/munit/ZFixtures.scala
+++ b/core/src/main/scala/munit/ZFixtures.scala
@@ -37,16 +37,17 @@ trait ZFixtures {
       )
 
     def apply[E, A](create: TestOptions => ZIO[Scope, E, A]): FunFixture[A] = {
-      val scope = Unsafe.unsafe { implicit unsafe =>
-        runtime.unsafe.run(Scope.make).getOrThrow()
-      }
+      var scope: Scope.Closeable = null
       FunFixture.async(
         setup = { options =>
-          unsafeRunToFuture(create(options).provideLayer(ZLayer.succeed(scope)))
+          val newScope = Unsafe.unsafe { implicit unsafe =>
+            runtime.unsafe.run(Scope.make).getOrThrow()
+          }
+          scope = newScope
+          unsafeRunToFuture(create(options).provideLayer(ZLayer.succeed(newScope)))
         },
         teardown = { resource =>
-          val effect = scope.close(Exit.succeed(resource)).unit
-          unsafeRunToFuture(effect)
+          unsafeRunToFuture(scope.close(Exit.succeed(resource)).unit)
         }
       )
     }

--- a/core/src/test/scala/munit/ZTestLocalFixturesSpec.scala
+++ b/core/src/test/scala/munit/ZTestLocalFixturesSpec.scala
@@ -28,4 +28,23 @@ class ZTestLocalFixturesSpec extends ZSuite {
       assertNoDiff(str1, "acquired compose ZIO FunFixtures")
       assertNoDiff(str2, "acquired compose ZIO FunFixtures with Scoped")
   }
+
+  // Regression test: scope must be fresh per test, not shared across tests
+  val activeResources = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  val scopeReuseFixture = ZTestLocalFixture { _ =>
+    ZIO.acquireRelease(
+      ZIO.succeed(activeResources.incrementAndGet())
+    )(_ => ZIO.succeed(activeResources.decrementAndGet()))
+  }
+
+  scopeReuseFixture.test("scope reuse - first test resource is active") { _ =>
+    assertEquals(activeResources.get(), 1)
+  }
+
+  scopeReuseFixture.test("scope reuse - second test resource is also active") { _ =>
+    // FAILS with the bug: scope from first test was closed in teardown,
+    // so finalizer runs immediately during setup of second test → counter == 0
+    assertEquals(activeResources.get(), 1)
+  }
 }


### PR DESCRIPTION
## Summary

- `ZTestLocalFixture` (scoped variant) created a single `Scope` at fixture definition time and shared it across all tests using that fixture
- After the first test's teardown closed the scope, subsequent tests would register ZIO finalizers into an already-closed scope — causing them to fire immediately during `setup`, releasing the resource before the test body ran
- Fix: move `Scope.make` inside the `setup` closure so each test gets a fresh scope; the `var` is safe because `FunFixture` executes setup/teardown sequentially

## Test plan

- [x] Added regression test `scope reuse - second test resource is also active` in `ZTestLocalFixturesSpec` — verified it **fails** before the fix (counter == 0 during test body) and **passes** after
- [x] Full test suite: `sbt "core/test"` — 31 tests, 0 failures

## Potential impacts

Only affects `ZTestLocalFixture.apply(create: TestOptions => ZIO[Scope, E, A])`. The raw setup/teardown overload and `ZSuiteLocalFixture` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)